### PR TITLE
Releases version 20210517.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debian/maratona-background.debhelper.log
 debian/maratona-background.substvars
 debian/maratona-background/
 debian/.debhelper
+debian/debhelper-build-stamp

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+maratona-background (20210517.1) focal; urgency=medium
+
+  * Update .gitignore
+  * Update maintainer, description and add VCS links
+  * Enable exit on failure for postinst
+  * Update machine-readable copyright file
+
+ -- Davi Antônio da Silva Santos <antoniossdavi@gmail.com>  Mon, 28 Jun 2021 20:26:57 -0300
+
 maratona-background (20210517) focal; urgency=medium
 
   [ Bruno Cesar Ribas ]

--- a/debian/control
+++ b/debian/control
@@ -1,11 +1,16 @@
 Source: maratona-background
 Section: misc
 Priority: optional
-Maintainer: Bruno Ribas <bruno.ribas@unb.br>
+Maintainer: Bruno César Ribas <bruno.ribas@unb.br>
 Build-Depends: debhelper-compat (= 12)
 Standards-Version: 3.9.8
+Vcs-Git: https://github.com/maratona-linux/maratona-background.git
+Vcs-Browser: https://github.com/maratona-linux/maratona-background
 
 Package: maratona-background
 Depends: dconf-cli
 Architecture: all
 Description: Pacote com o background atualizado da Maratona
+ Este pacote realiza as alterações necessárias no sistema para que o plano de
+ fundo da área de trabalho seja substituído pelo configurado para a Maratona
+ Linux

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,14 +1,12 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: maratona-background
-Source: <url://example.com>
+Source: <https://github.com/maratona-linux/maratona-background>
 
 Files: *
-Copyright: <years> <put author's name and email here>
-           <years> <likewise for another author>
-License: GPL-2.0+
-
-Files: debian/*
-Copyright: 2016 Bruno Ribas <brunoribas@utfpr.edu.br>
+Copyright: 2016-2021 Bruno César Ribas <bruno.ribas@unb.br>
+           2021 Davi Antônio da Silva Santos <antoniossdavi@gmail.com>
+           2020 Guilherme Antonio Deusdará Banci <guibanci@gmail.com>
+           2018 Wall Berg Morais <wallbergmirandamorais@gmail.com>
 License: GPL-2.0+
 
 License: GPL-2.0+
@@ -27,8 +25,3 @@ License: GPL-2.0+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
-
-# Please also look if there are files or directories which have a
-# different copyright/license attached and list them here.
-# Please avoid picking licenses with terms that are more restrictive than the
-# packaged work, as it may make Debian's contributions unacceptable upstream.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -e
+
 dconf update


### PR DESCRIPTION
- Updates copyright information, `.gitignore`, maintainer, descriptions and 
  enables exit on failure
- Closes #7